### PR TITLE
Tweaks and unit tests for token bids, cleanup in others

### DIFF
--- a/contracts/marketplace/KODAV3Marketplace.sol
+++ b/contracts/marketplace/KODAV3Marketplace.sol
@@ -486,9 +486,11 @@ contract KODAV3Marketplace is ReentrancyGuard, IKODAV3PrimarySaleMarketplace, IK
     /////////////////////////////////
 
     function placeTokenBid(uint256 _tokenId) public payable override nonReentrant {
+        // Check for highest offer
         Offer storage offer = tokenOffers[_tokenId];
-        require(offer.offer.add(minBidAmount) >= msg.value, "Bid not high enough");
+        require(msg.value >= offer.offer.add(minBidAmount), "Bid not high enough");
 
+        // TODO create testing contract for this
         // No contracts can place a bid to prevent money lockups on refunds
         require(!Address.isContract(_msgSender()), "Cannot make an offer as a contract");
 
@@ -505,6 +507,9 @@ contract KODAV3Marketplace is ReentrancyGuard, IKODAV3PrimarySaleMarketplace, IK
 
     function withdrawTokenBid(uint256 _tokenId) public override nonReentrant {
         Offer storage offer = tokenOffers[_tokenId];
+        require(offer.bidder != address(0), "No open bid");
+
+        // caller must be bidder
         require(offer.bidder == _msgSender(), "Not bidder");
 
         // send money back to top bidder
@@ -517,7 +522,7 @@ contract KODAV3Marketplace is ReentrancyGuard, IKODAV3PrimarySaleMarketplace, IK
     }
 
     function rejectTokenBid(uint256 _tokenId) public override nonReentrant {
-        Offer storage offer = tokenOffers[_tokenId];
+        Offer memory offer = tokenOffers[_tokenId];
         require(offer.bidder != address(0), "No open bid");
 
         address currentOwner = koda.ownerOf(_tokenId);
@@ -533,7 +538,7 @@ contract KODAV3Marketplace is ReentrancyGuard, IKODAV3PrimarySaleMarketplace, IK
     }
 
     function acceptTokenBid(uint256 _tokenId, uint256 _offerPrice) public override nonReentrant {
-        Offer storage offer = tokenOffers[_tokenId];
+        Offer memory offer = tokenOffers[_tokenId];
         require(offer.bidder != address(0), "No open bid");
         require(offer.offer == _offerPrice, "Offer price has changed");
 

--- a/test/marketplace/KODAV3Marketplace.stepped.sales.test.js
+++ b/test/marketplace/KODAV3Marketplace.stepped.sales.test.js
@@ -1,19 +1,14 @@
 const {BN, constants, time, expectEvent, expectRevert, balance} = require('@openzeppelin/test-helpers');
 const {ZERO_ADDRESS} = constants;
 
-const _ = require('lodash');
-
 const web3 = require('web3');
 const {ether} = require("@openzeppelin/test-helpers");
-
 const {expect} = require('chai');
 
 const KnownOriginDigitalAssetV3 = artifacts.require('KnownOriginDigitalAssetV3');
 const KODAV3Marketplace = artifacts.require('KODAV3Marketplace');
 const KOAccessControls = artifacts.require('KOAccessControls');
 const SelfServiceAccessControls = artifacts.require('SelfServiceAccessControls');
-
-const {validateEditionAndToken} = require('../test-helpers');
 
 contract('KODAV3Marketplace', function (accounts) {
   const [owner, minter, koCommission, contract, collectorA, collectorB, collectorC, collectorD] = accounts;
@@ -22,7 +17,6 @@ contract('KODAV3Marketplace', function (accounts) {
 
   const STARTING_EDITION = '10000';
 
-  const ETH_ONE = ether('1');
   const ONE = new BN('1');
   const ZERO = new BN('0');
 
@@ -30,7 +24,6 @@ contract('KODAV3Marketplace', function (accounts) {
   const _0_1_ETH = ether('0.1');
   const _1_ETH = ether('1');
   const _1_5_ETH = ether('1.5');
-  const _0_5_ETH = ether('0.5');
 
   const firstEditionTokenId = new BN('11000');
   const secondEditionTokenId = new BN('12000');
@@ -486,7 +479,7 @@ contract('KODAV3Marketplace', function (accounts) {
 
       });
 
-      it('cannot be converted unless list price is equal to or greater than minimum bid', async () => {
+      it('reverts unless list price is equal to or greater than minimum bid', async () => {
 
         const edition = firstEditionTokenId;
         const listingPrice = ZERO;

--- a/test/marketplace/KODAV3Marketplace.test.js
+++ b/test/marketplace/KODAV3Marketplace.test.js
@@ -1,11 +1,7 @@
 const {BN, constants, time, expectEvent, expectRevert, balance} = require('@openzeppelin/test-helpers');
 const {ZERO_ADDRESS} = constants;
-
 const _ = require('lodash');
-
-const web3 = require('web3');
 const {ether} = require('@openzeppelin/test-helpers');
-
 const {expect} = require('chai');
 
 const KnownOriginDigitalAssetV3 = artifacts.require('KnownOriginDigitalAssetV3');
@@ -23,14 +19,11 @@ contract('KODAV3Marketplace', function (accounts) {
   const STARTING_EDITION = '10000';
 
   const _0_1_ETH = ether('0.1');
-  const ETH_ONE = ether('1');
   const ONE = new BN('1');
   const ZERO = new BN('0');
 
   const firstEditionTokenId = new BN('11000');
   const secondEditionTokenId = new BN('12000');
-  const thirdEditionTokenId = new BN('13000');
-  const nonExistentTokenId = new BN('99999999999');
 
   beforeEach(async () => {
     const legacyAccessControls = await SelfServiceAccessControls.new();
@@ -188,7 +181,7 @@ contract('KODAV3Marketplace', function (accounts) {
       // Ensure owner is approved as this will fail if not
       await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
 
-      // create 100 tokens to the minter
+      // create 3 tokens to the minter
       await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
 
       this.start = await time.latest();
@@ -262,7 +255,7 @@ contract('KODAV3Marketplace', function (accounts) {
         // Ensure owner is approved as this will fail if not
         await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
 
-        // create 100 tokens to the minter
+        // create 3 tokens to the minter
         await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
 
         this.start = await time.latest();
@@ -320,7 +313,7 @@ contract('KODAV3Marketplace', function (accounts) {
       // Ensure owner is approved as this will fail if not
       await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
 
-      // create 100 tokens to the minter
+      // create 3 tokens to the minter
       await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
 
       this.start = await time.latest();
@@ -491,7 +484,7 @@ contract('KODAV3Marketplace', function (accounts) {
         // Ensure owner is approved as this will fail if not
         await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
 
-        // create 100 tokens to the minter
+        // create 3 tokens to the minter
         await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
 
         const start = await time.latest();
@@ -558,7 +551,7 @@ contract('KODAV3Marketplace', function (accounts) {
         // Ensure owner is approved as this will fail if not
         await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
 
-        // create 100 tokens to the minter
+        // create 3 tokens to the minter
         await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
 
         const start = await time.latest();
@@ -620,7 +613,7 @@ contract('KODAV3Marketplace', function (accounts) {
         // Ensure owner is approved as this will fail if not
         await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
 
-        // create 100 tokens to the minter
+        // create 3 tokens to the minter
         await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
 
         const start = await time.latest();

--- a/test/marketplace/KODAV3Marketplace.token.bids.test.js
+++ b/test/marketplace/KODAV3Marketplace.token.bids.test.js
@@ -1,0 +1,592 @@
+const {BN, constants, time, expectEvent, expectRevert, balance} = require('@openzeppelin/test-helpers');
+const {ZERO_ADDRESS} = constants;
+const _ = require('lodash');
+const {ether} = require('@openzeppelin/test-helpers');
+const {expect} = require('chai');
+
+const KnownOriginDigitalAssetV3 = artifacts.require('KnownOriginDigitalAssetV3');
+const KODAV3Marketplace = artifacts.require('KODAV3Marketplace');
+const KOAccessControls = artifacts.require('KOAccessControls');
+const SelfServiceAccessControls = artifacts.require('SelfServiceAccessControls');
+
+contract('KODAV3Marketplace token bids', function (accounts) {
+  const [owner, minter, koCommission, contract, collectorA, collectorB] = accounts;
+
+  const TOKEN_URI = 'ipfs://ipfs/Qmd9xQFBfqMZLG7RA2rXor7SA7qyJ1Pk2F2mSYzRQ2siMv';
+
+  const STARTING_EDITION = '10000';
+  const MIN_BID = ether('0.01');
+
+  const firstTokenId = new BN('11000');
+
+  beforeEach(async () => {
+    const legacyAccessControls = await SelfServiceAccessControls.new();
+    // setup access controls
+    this.accessControls = await KOAccessControls.new(legacyAccessControls.address, {from: owner});
+
+    // grab the roles
+    this.MINTER_ROLE = await this.accessControls.MINTER_ROLE();
+    this.CONTRACT_ROLE = await this.accessControls.CONTRACT_ROLE();
+
+    // Set up access controls with minter roles
+    await this.accessControls.grantRole(this.MINTER_ROLE, owner, {from: owner});
+    await this.accessControls.grantRole(this.MINTER_ROLE, minter, {from: owner});
+
+    // Create token V3
+    this.token = await KnownOriginDigitalAssetV3.new(
+        this.accessControls.address,
+        ZERO_ADDRESS, // no royalties address
+        STARTING_EDITION,
+        {from: owner}
+    );
+
+    // Set contract roles
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, this.token.address, {from: owner});
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, contract, {from: owner});
+
+    // Create marketplace and enable in whitelist
+    this.marketplace = await KODAV3Marketplace.new(this.accessControls.address, this.token.address, koCommission, {from: owner});
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, this.marketplace.address, {from: owner});
+
+    this.minBidAmount = await this.marketplace.minBidAmount();
+  });
+
+  describe('secondary sale token offers', async () => {
+
+    describe('placeTokenBid()', () => {
+
+      const _0_5_ETH = ether('0.5');
+
+      beforeEach(async () => {
+
+        // Ensure owner is approved as this will fail if not
+        await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
+
+        // create 3 tokens to the minter
+        await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
+
+      });
+
+      it('reverts if bid lower than minimum on first bid', async () => {
+
+        const token = firstTokenId;
+        const BID_TOO_LOW = ether('0.00001');
+
+        // collector B places offer 0.50001 ETH for token (too low)
+        await expectRevert(
+            this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_TOO_LOW}),
+            'Bid not high enough'
+        );
+      });
+
+      it('reverts if bid lower than existing bid plus minimum', async () => {
+
+        const token = firstTokenId;
+        const BID_TOO_LOW = ether('0.500001');
+
+        // collector A places offer 0.5 ETH for token
+        await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+        // collector B places offer 0.50001 ETH for token (too low)
+        await expectRevert(
+            this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_TOO_LOW}),
+            'Bid not high enough'
+        );
+      });
+
+      it('reverts if bid lower than minimum after an outbidding', async () => {
+
+        const token = firstTokenId;
+        const BID_OK = ether('0.51');
+        const BID_TOO_LOW = ether('0.510001');
+
+        // collector A places offer 0.5 ETH for token
+        await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+        // collector B places offer 0.51 ETH for token, outbidding collector A
+        await this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_OK});
+
+        // collector C places offer 0.510001 ETH for token (too low for next bid)
+        await expectRevert(
+            this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_TOO_LOW}),
+            'Bid not high enough'
+        );
+
+      });
+
+      describe('on success', () => {
+
+        it('emits TokenBidPlaced event on successful bid', async () => {
+
+          const token = firstTokenId;
+
+          // offer minimum bid for token
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorA,
+            _amount: _0_5_ETH
+          });
+
+        });
+
+        it('can place minimum bid as first bid on token', async () => {
+
+          const token = firstTokenId;
+
+          // offer minimum bid for token
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorA, value: MIN_BID});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorA,
+            _amount: MIN_BID
+          });
+
+        });
+
+        it('can outbid previous high bidder', async () => {
+
+          const token = firstTokenId;
+          const BID_OK = ether('0.51');
+
+          // collector A places offer 0.5 ETH for token
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // collector B places offer 0.51 ETH for token (ok bid)
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_OK});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorB,
+            _amount: BID_OK
+          });
+
+
+        });
+
+        it('previous bidder refunded when outbid', async () => {
+
+          const token = firstTokenId;
+          const BID_OK = ether('0.51');
+
+          // collector A places offer 0.5 ETH for token
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // Get the buyer's starting wallet balance
+          const tracker = await balance.tracker(collectorA);
+          const startBalance = await tracker.get();
+
+          // collector B places offer 0.51 ETH for token (ok bid)
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_OK});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorB,
+            _amount: BID_OK
+          });
+
+          // Expected balance is starting balance plus .5 ETH, the previous bid amount
+          const expectedBalance = startBalance.add(_0_5_ETH);
+          const endBalance = await tracker.get();
+          expect(endBalance).to.be.bignumber.equal(expectedBalance);
+
+        });
+
+        it('cannot bid again with same amount', async () => {
+
+          const token = firstTokenId;
+          const BID_OK = ether('0.51');
+
+          // collector A places offer 0.5 ETH for token
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // attempt to bid again with same offer
+          await expectRevert(
+              this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH}),
+              'Bid not high enough'
+          );
+
+        });
+
+      });
+
+    });
+
+    describe('withdrawTokenBid()', () => {
+
+      const _0_5_ETH = ether('0.5');
+
+      beforeEach(async () => {
+
+        // Ensure owner is approved as this will fail if not
+        await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
+
+        // create 3 tokens to the minter
+        await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
+
+      });
+
+      it('reverts if no current bid', async () => {
+
+        const token = firstTokenId;
+
+        // collector A attempts to withdraw bid when none exists
+        await expectRevert(
+            this.marketplace.withdrawTokenBid(token, {from: collectorA}),
+            'No open bid'
+        );
+
+      });
+
+      it('reverts if not bidder', async () => {
+
+        const token = firstTokenId;
+
+        // collector A places offer 0.5 ETH for token
+        await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+        // collector B attempts to withdraw collecter A's bid
+        await expectRevert(
+            this.marketplace.withdrawTokenBid(token, {from: collectorB}),
+            'Not bidder'
+        );
+
+      });
+
+      describe('on success', () => {
+
+        it('can place first bid on token then withdraw it', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // withdraw bid
+          const receipt = await this.marketplace.withdrawTokenBid(token, {from: collectorA});
+          expectEvent(receipt, 'TokenBidWithdrawn', {
+            _tokenId: token,
+            _bidder: collectorA
+          });
+
+        });
+
+        it('emits TokenBidWithdrawn event on successful withdrawal', async () => {
+
+          const token = firstTokenId;
+          const BID_OK = ether('0.51');
+
+          // collector A offers 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // collector B outbids
+          await this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_OK});
+
+          // collector B withdraws bid
+          const receipt = await this.marketplace.withdrawTokenBid(token, {from: collectorB});
+          expectEvent(receipt, 'TokenBidWithdrawn', {
+            _tokenId: token,
+            _bidder: collectorB
+          });
+
+        });
+
+        it('previous bidder refunded when outbid', async () => {
+
+          const token = firstTokenId;
+          const BID_OK = ether('0.51');
+
+          // collector A places offer 0.5 ETH for token
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // Get the buyer's starting wallet balance
+          const tracker = await balance.tracker(collectorA);
+          const startBalance = await tracker.get();
+
+          // collector B places offer 0.51 ETH for token (ok bid)
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorB, value: BID_OK});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorB,
+            _amount: BID_OK
+          });
+
+          // Expected balance is starting balance plus .5 ETH, the previous bid amount
+          const expectedBalance = startBalance.add(_0_5_ETH);
+          const endBalance = await tracker.get();
+          expect(endBalance).to.be.bignumber.equal(expectedBalance);
+
+        });
+
+        it('can place minimum bid after highest is withdrawn', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // withdraw bid
+          await this.marketplace.withdrawTokenBid(token, {from: collectorA});
+
+          // offer minimum bid for token
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorB, value: MIN_BID});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorB,
+            _amount: MIN_BID
+          });
+
+        });
+
+        it('cannot withdraw bid twice', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // withdraw bid
+          await this.marketplace.withdrawTokenBid(token, {from: collectorA});
+
+          // attempt to withdraw bid again
+          await expectRevert(
+              this.marketplace.withdrawTokenBid(token, {from: collectorA}),
+              'No open bid'
+          );
+
+        });
+
+      });
+
+    });
+
+    describe('rejectTokenBid()', () => {
+
+      const _0_5_ETH = ether('0.5');
+
+      beforeEach(async () => {
+
+        // Ensure owner is approved as this will fail if not
+        await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
+
+        // create 3 tokens to the minter
+        await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
+
+      });
+
+      it('reverts if no current bid', async () => {
+
+        const token = firstTokenId;
+
+        // minter attempts to reject bid when none exists
+        await expectRevert(
+            this.marketplace.rejectTokenBid(token, {from: minter}),
+            'No open bid'
+        );
+
+      });
+
+      it('reverts if not current owner', async () => {
+
+        const token = firstTokenId;
+
+        // collector A places offer 0.5 ETH for token
+        await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+        // collector B attempts to reject collecter A's bid
+        await expectRevert(
+            this.marketplace.rejectTokenBid(token, {from: collectorB}),
+            'Not current owner'
+        );
+
+      });
+
+      describe('on success', () => {
+
+        it('emits TokenBidRejected event when owner rejects offer', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // reject bid
+          const receipt = await this.marketplace.rejectTokenBid(token, {from: minter});
+          expectEvent(receipt, 'TokenBidRejected', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorA,
+            _amount: _0_5_ETH
+          });
+
+        });
+
+        it('high bidder refunded when rejected', async () => {
+
+          const token = firstTokenId;
+
+          // collector A places offer 0.5 ETH for token
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // get the buyer's starting wallet balance
+          const tracker = await balance.tracker(collectorA);
+          const startBalance = await tracker.get();
+
+          // owner rejects bid
+          await this.marketplace.rejectTokenBid(token, {from: minter});
+
+          // collector A's expected balance is starting balance plus .5 ETH, the previous bid amount
+          const expectedBalance = startBalance.add(_0_5_ETH);
+          const endBalance = await tracker.get();
+          expect(endBalance).to.be.bignumber.equal(expectedBalance);
+
+        });
+
+        it('can place minimum bid after highest is rejected', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // reject bid
+          await this.marketplace.rejectTokenBid(token, {from: minter});
+
+          // offer minimum bid for token
+          const receipt = await this.marketplace.placeTokenBid(token, {from: collectorB, value: MIN_BID});
+          expectEvent(receipt, 'TokenBidPlaced', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorB,
+            _amount: MIN_BID
+          });
+
+        });
+
+        it('owner cannot reject offer twice', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // reject bid
+          await this.marketplace.rejectTokenBid(token, {from: minter});
+
+          // attempt to reject bid again
+          await expectRevert(
+              this.marketplace.rejectTokenBid(token, {from: minter}),
+              'No open bid'
+          );
+
+        });
+
+      })
+
+    });
+
+    describe('acceptTokenBid()', () => {
+
+      const _0_5_ETH = ether('0.5');
+
+      beforeEach(async () => {
+
+        // Ensure owner is approved as this will fail if not
+        await this.token.setApprovalForAll(this.marketplace.address, true, {from: minter});
+
+        // create 3 tokens to the minter
+        await this.token.mintBatchEdition(3, minter, TOKEN_URI, {from: contract});
+
+      });
+
+      it('reverts if no current bid', async () => {
+
+        const token = firstTokenId;
+
+        // minter attempts to reject bid when none exists
+        await expectRevert(
+            this.marketplace.acceptTokenBid(token, _0_5_ETH, {from: minter}),
+            'No open bid'
+        );
+
+      });
+
+      it('reverts if not current owner', async () => {
+
+        const token = firstTokenId;
+
+        // collector A places offer 0.5 ETH for token
+        await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+        // collector B attempts to reject collecter A's bid
+        await expectRevert(
+            this.marketplace.acceptTokenBid(token, _0_5_ETH, {from: collectorB}),
+            'Not current owner'
+        );
+
+      });
+
+      describe('on success', () => {
+
+        it('emits TokenBidAccepted event when owner accepts offer', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // accept bid
+          const receipt = await this.marketplace.acceptTokenBid(token, _0_5_ETH, {from: minter});
+          expectEvent(receipt, 'TokenBidAccepted', {
+            _tokenId: token,
+            _currentOwner: minter,
+            _bidder: collectorA,
+            _amount: _0_5_ETH
+          });
+
+        });
+
+        it('owner cannot accept offer twice', async () => {
+
+          const token = firstTokenId;
+
+          // offer 0.5 ETH for token (first bid)
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // accept bid
+          await this.marketplace.acceptTokenBid(token, _0_5_ETH, {from: minter});
+
+          // attempt to accept offer twice
+          await expectRevert(
+              this.marketplace.acceptTokenBid(token, _0_5_ETH, {from: minter}),
+              'No open bid'
+          );
+
+        });
+
+        it('bidder receives token after owner accepts bid', async () => {
+
+          const token = firstTokenId;
+
+          // collector A offers 0.5 ETH for token
+          await this.marketplace.placeTokenBid(token, {from: collectorA, value: _0_5_ETH});
+
+          // accept bid
+          await this.marketplace.acceptTokenBid(token, _0_5_ETH, {from: minter});
+
+          // Owner is collector A
+          expect(await this.token.ownerOf(token)).to.be.equal(collectorA);
+
+        });
+
+      })
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
* In KODAV3Marketplace.sol,
  - in placeTokenBid method,
    - fix revert if bid amount isn't greater than existing bid plus minimum amount
    - add TODO to add a testing contract for making sure that a contract can't place a bid
  - in withdrawTokenBid
    - revert if there's no open bid
  - in rejectTokenBid,
    - load offer into memory, so that after delete, the event can send the info about the deleted offer
  - in acceptTokenBid,
    - load offer into memory, so that after delete, the event can send the info about the accepted offer

* In KODAV3Marketplace.stepped.sales.test.js,
  - remove unused imports and constants
  - minor change to a test description

* In KODAV3Marketplace.test.js,
  - remove unused imports and constants
  - update some comments in tests about tokens created

* Added KODAV3Marketplace.token.bids.test.js,
  - for tests of secondary sale token offers
  - tests for placeTokenBid method include
    - reverts if bid lower than minimum on first bid
    - reverts if bid lower than existing bid plus minimum
    - reverts if bid lower than minimum after an outbidding
    - emits TokenBidPlaced event on successful bid
    - can place minimum bid as first bid on token
    - can outbid previous high bidder
    - previous bidder refunded when outbid
    - cannot bid again with same amount
  - tests for withdrawTokenBid method include
    - reverts if no current bid
    - reverts if not bidder
    - can place first bid on token then withdraw it
    - emits TokenBidWithdrawn event on successful withdrawal
    - previous bidder refunded when outbid
    - can place minimum bid after highest is withdrawn
    - cannot withdraw bid twice
  - tests for rejectTokenBid method include
    - reverts if no current bid
    - reverts if not current owner
    - emits TokenBidRejected event when owner rejects offer
    - high bidder refunded when rejected
    - can place minimum bid after highest is rejected
    - owner cannot reject offer twice
  - tests for acceptTokenBid method include
    - reverts if no current bid
    - reverts if not current owner
    - emits TokenBidAccepted event when owner accepts offer
    - owner cannot accept offer twice
    - bidder receives token after owner accepts bid