### PR TITLE
Minting gated editions

### DIFF
--- a/.openzeppelin/unknown-31337.json
+++ b/.openzeppelin/unknown-31337.json
@@ -1616,11 +1616,6 @@
       "kind": "uups"
     },
     {
-      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-      "txHash": "0x85b97826db1fd4623c18f9848cea14a7b4e9508510d0fb16192c34552909c308",
-      "kind": "uups"
-    },
-    {
       "address": "0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1",
       "txHash": "0xa0b1e5de2508b1aabe4b200ee42340eb83f37178690565339bfeb31a92cc8f4c",
       "kind": "uups"
@@ -1633,6 +1628,11 @@
     {
       "address": "0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9",
       "txHash": "0x4c393706a931d4427541610c3fec0242447dbe79cc3d39954b3b32b0a1831f79",
+      "kind": "uups"
+    },
+    {
+      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+      "txHash": "0x85b97826db1fd4623c18f9848cea14a7b4e9508510d0fb16192c34552909c308",
       "kind": "uups"
     }
   ],
@@ -2730,9 +2730,9 @@
         }
       }
     },
-    "8f084558c4cb9c4159a2b6687247e8e9c4275db5b4483c430c2e68833d7fcf97": {
+    "aded78bdfcb6ca6996ad61b760f5e54d6136c863431ff9e2919c8a2218e5d1fc": {
       "address": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
-      "txHash": "0x052a9bf1a8918e12f548fa2cab177c93d9df8826d13ea2fddad75eec15cfc8f8",
+      "txHash": "0x6e8cf185a5c5c76b1af576c82ec56e07f17cd7c28e6e7588bc8f7de8bcf5bfea",
       "layout": {
         "storage": [
           {
@@ -2835,37 +2835,37 @@
             "contract": "KODAV3UpgradableGatedMarketplace",
             "label": "koCommissionOverrideForSale",
             "type": "t_mapping(t_uint256,t_struct(KOCommissionOverride)12230_storage)",
-            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:66"
+            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:70"
           },
           {
             "contract": "KODAV3UpgradableGatedMarketplace",
             "label": "saleIdCounter",
             "type": "t_uint256",
-            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:69"
+            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:73"
           },
           {
             "contract": "KODAV3UpgradableGatedMarketplace",
             "label": "totalMints",
             "type": "t_mapping(t_bytes32,t_uint256)",
-            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:72"
+            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:76"
           },
           {
             "contract": "KODAV3UpgradableGatedMarketplace",
             "label": "editionToSale",
             "type": "t_mapping(t_uint256,t_uint256)",
-            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:75"
+            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:79"
           },
           {
             "contract": "KODAV3UpgradableGatedMarketplace",
             "label": "sales",
-            "type": "t_mapping(t_uint256,t_struct(Sale)16249_storage)",
-            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:78"
+            "type": "t_mapping(t_uint256,t_struct(Sale)16342_storage)",
+            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:82"
           },
           {
             "contract": "KODAV3UpgradableGatedMarketplace",
             "label": "phases",
-            "type": "t_mapping(t_uint256,t_array(t_struct(Phase)16234_storage)dyn_storage)",
-            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:81"
+            "type": "t_mapping(t_uint256,t_array(t_struct(Phase)16327_storage)dyn_storage)",
+            "src": "contracts/marketplace/KODAV3UpgradableGatedMarketplace.sol:85"
           }
         ],
         "types": {
@@ -2900,10 +2900,10 @@
           "t_mapping(t_uint256,t_uint256)": {
             "label": "mapping(uint256 => uint256)"
           },
-          "t_mapping(t_uint256,t_struct(Sale)16249_storage)": {
+          "t_mapping(t_uint256,t_struct(Sale)16342_storage)": {
             "label": "mapping(uint256 => struct KODAV3UpgradableGatedMarketplace.Sale)"
           },
-          "t_struct(Sale)16249_storage": {
+          "t_struct(Sale)16342_storage": {
             "label": "struct KODAV3UpgradableGatedMarketplace.Sale",
             "members": [
               {
@@ -2945,13 +2945,13 @@
           "t_uint8": {
             "label": "uint8"
           },
-          "t_mapping(t_uint256,t_array(t_struct(Phase)16234_storage)dyn_storage)": {
+          "t_mapping(t_uint256,t_array(t_struct(Phase)16327_storage)dyn_storage)": {
             "label": "mapping(uint256 => struct KODAV3UpgradableGatedMarketplace.Phase[])"
           },
-          "t_array(t_struct(Phase)16234_storage)dyn_storage": {
+          "t_array(t_struct(Phase)16327_storage)dyn_storage": {
             "label": "struct KODAV3UpgradableGatedMarketplace.Phase[]"
           },
-          "t_struct(Phase)16234_storage": {
+          "t_struct(Phase)16327_storage": {
             "label": "struct KODAV3UpgradableGatedMarketplace.Phase",
             "members": [
               {

--- a/abis/KODAV3UpgradableGatedMarketplace.json
+++ b/abis/KODAV3UpgradableGatedMarketplace.json
@@ -407,6 +407,19 @@
         "type": "uint256"
       }
     ],
+    "name": "SaleCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_saleId",
+        "type": "uint256"
+      }
+    ],
     "name": "SalePaused",
     "type": "event"
   },
@@ -532,6 +545,67 @@
       }
     ],
     "name": "createPhase",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_editionId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "_startTimes",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "_endTimes",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "_pricesInWei",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint16[]",
+        "name": "_mintCaps",
+        "type": "uint16[]"
+      },
+      {
+        "internalType": "uint16[]",
+        "name": "_walletMintLimits",
+        "type": "uint16[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleRoots",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_merkleIPFSHashes",
+        "type": "string[]"
+      }
+    ],
+    "name": "createPhases",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_editionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "createSale",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/abis/MintingFactoryV2.json
+++ b/abis/MintingFactoryV2.json
@@ -1,0 +1,543 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_override",
+        "type": "bool"
+      }
+    ],
+    "name": "AdminFrequencyOverrideChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_maxMintsInPeriod",
+        "type": "uint256"
+      }
+    ],
+    "name": "AdminMaxMintsInPeriodChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_mintingPeriod",
+        "type": "uint256"
+      }
+    ],
+    "name": "AdminMintingPeriodChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_royaltiesRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "AdminRoyaltiesRegistryChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_editionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum MintingFactoryV2.SaleType",
+        "name": "_saleType",
+        "type": "uint8"
+      }
+    ],
+    "name": "EditionMintedAndListed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "MintingFactoryCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "accessControls",
+    "outputs": [
+      {
+        "internalType": "contract IKOAccessControlsLookup",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "canCreateNewEdition",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "currentMintConfig",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "mints",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "firstMintInPeriod",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "frequencyOverride",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gatedMarketplace",
+    "outputs": [
+      {
+        "internalType": "contract IKODAV3GatedMarketplace",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IKOAccessControlsLookup",
+        "name": "_accessControls",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IKODAV3Minter",
+        "name": "_koda",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IKODAV3PrimarySaleMarketplace",
+        "name": "_marketplace",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IKODAV3GatedMarketplace",
+        "name": "_gatedMarketplace",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ICollabRoyaltiesRegistry",
+        "name": "_royaltiesRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "koda",
+    "outputs": [
+      {
+        "internalType": "contract IKODAV3Minter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marketplace",
+    "outputs": [
+      {
+        "internalType": "contract IKODAV3PrimarySaleMarketplace",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxMintsInPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum MintingFactoryV2.SaleType",
+        "name": "_saleType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_editionSize",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_startDate",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_basePrice",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_stepPrice",
+        "type": "uint128"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_merkleIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_deployedRoyaltiesHandler",
+        "type": "address"
+      }
+    ],
+    "name": "mintBatchEdition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "enum MintingFactoryV2.SaleType",
+        "name": "_saleType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_editionSize",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_startDate",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_basePrice",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_stepPrice",
+        "type": "uint128"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_deployedRoyaltiesHandler",
+        "type": "address"
+      }
+    ],
+    "name": "mintBatchEditionAsProxy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "_editionSize",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_merkleIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_deployedRoyaltiesHandler",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      }
+    ],
+    "name": "mintBatchGatedEdition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintingPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "royaltiesRegistry",
+    "outputs": [
+      {
+        "internalType": "contract ICollabRoyaltiesRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_override",
+        "type": "bool"
+      }
+    ],
+    "name": "setFrequencyOverride",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxMintsInPeriod",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxMintsInPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_mintingPeriod",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMintingPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract ICollabRoyaltiesRegistry",
+        "name": "_royaltiesRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "setRoyaltiesRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/abis/MintingFactoryV2.json
+++ b/abis/MintingFactoryV2.json
@@ -421,7 +421,78 @@
         "type": "string"
       }
     ],
+    "name": "mintBatchEditionOnly",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "_editionSize",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_merkleIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_deployedRoyaltiesHandler",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      }
+    ],
     "name": "mintBatchGatedEdition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_editionSize",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_merkleIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_deployedRoyaltiesHandler",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      }
+    ],
+    "name": "mintBatchGatedEditionAsProxy",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/abis/MockKODAV3UpgradableGatedMarketplace.json
+++ b/abis/MockKODAV3UpgradableGatedMarketplace.json
@@ -407,6 +407,19 @@
         "type": "uint256"
       }
     ],
+    "name": "SaleCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_saleId",
+        "type": "uint256"
+      }
+    ],
     "name": "SalePaused",
     "type": "event"
   },
@@ -532,6 +545,67 @@
       }
     ],
     "name": "createPhase",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_editionId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "_startTimes",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "_endTimes",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "_pricesInWei",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint16[]",
+        "name": "_mintCaps",
+        "type": "uint16[]"
+      },
+      {
+        "internalType": "uint16[]",
+        "name": "_walletMintLimits",
+        "type": "uint16[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleRoots",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_merkleIPFSHashes",
+        "type": "string[]"
+      }
+    ],
+    "name": "createPhases",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_editionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "createSale",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/marketplace/IKODAV3Marketplace.sol
+++ b/contracts/marketplace/IKODAV3Marketplace.sol
@@ -127,3 +127,43 @@ interface IKODAV3SecondarySaleMarketplace is ITokenBuyNowMarketplace, ITokenOffe
 
     function convertReserveAuctionToOffers(uint256 _tokenId) external;
 }
+
+interface IKODAV3GatedMarketplace {
+
+    function createSale(uint256 _editionId) external;
+
+    function createPhase(
+        uint256 _editionId,
+        uint128 _startTime,
+        uint128 _endTime,
+        uint128 _priceInWei,
+        uint16 _mintCap,
+        uint16 _walletMintLimit,
+        bytes32 _merkleRoot,
+        string calldata _merkleIPFSHash
+    ) external;
+
+    function createSaleWithPhases(
+        uint256 _editionId,
+        uint128[] memory _startTimes,
+        uint128[] memory _endTimes,
+        uint128[] memory _pricesInWei,
+        uint16[] memory _mintCaps,
+        uint16[] memory _walletMintLimits,
+        bytes32[] memory _merkleRoots,
+        string[] memory _merkleIPFSHashes
+    ) external;
+
+    function createPhases(
+        uint256 _editionId,
+        uint128[] memory _startTimes,
+        uint128[] memory _endTimes,
+        uint128[] memory _pricesInWei,
+        uint16[] memory _mintCaps,
+        uint16[] memory _walletMintLimits,
+        bytes32[] memory _merkleRoots,
+        string[] memory _merkleIPFSHashes
+    ) external;
+
+    function removePhase(uint256 _editionId, uint256 _phaseId) external;
+}

--- a/contracts/minter/MintingFactoryV2.sol
+++ b/contracts/minter/MintingFactoryV2.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import {IKODAV3Minter} from "../core/IKODAV3Minter.sol";
+import {
+IKODAV3PrimarySaleMarketplace,
+IKODAV3GatedMarketplace
+} from "../marketplace/IKODAV3Marketplace.sol";
+import {ICollabRoyaltiesRegistry} from "../collab/ICollabRoyaltiesRegistry.sol";
+import {IKOAccessControlsLookup} from "../access/IKOAccessControlsLookup.sol";
+
+contract MintingFactoryV2 is Context, UUPSUpgradeable {
+
+    event EditionMintedAndListed(uint256 indexed _editionId, SaleType _saleType);
+
+    event MintingFactoryCreated();
+    event AdminMintingPeriodChanged(uint256 _mintingPeriod);
+    event AdminMaxMintsInPeriodChanged(uint256 _maxMintsInPeriod);
+    event AdminFrequencyOverrideChanged(address _account, bool _override);
+    event AdminRoyaltiesRegistryChanged(address _royaltiesRegistry);
+
+    modifier onlyAdmin() {
+        require(accessControls.hasAdminRole(_msgSender()), "Caller must have admin role");
+        _;
+    }
+
+    modifier canMintAgain(){
+        require(_canCreateNewEdition(_msgSender()), "Caller unable to create yet");
+        _;
+    }
+
+    struct MintingPeriod {
+        uint128 mints;
+        uint128 firstMintInPeriod;
+    }
+
+    enum SaleType {
+        BUY_NOW, OFFERS, STEPPED, RESERVE, GATED
+    }
+
+    // Minting allowance period
+    uint256 public mintingPeriod = 30 days;
+
+    // Limit of mints with in the period
+    uint256 public maxMintsInPeriod = 15;
+
+    // Frequency override list for users - you can temporarily add in address which disables the freeze time check
+    mapping(address => bool) public frequencyOverride;
+
+    // How many mints within the current minting period
+    mapping(address => MintingPeriod) mintingPeriodConfig;
+
+    IKOAccessControlsLookup public accessControls;
+    IKODAV3Minter public koda;
+    IKODAV3PrimarySaleMarketplace public marketplace;
+    IKODAV3GatedMarketplace public gatedMarketplace;
+    ICollabRoyaltiesRegistry public royaltiesRegistry;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() initializer {}
+
+    function initialize(
+        IKOAccessControlsLookup _accessControls,
+        IKODAV3Minter _koda,
+        IKODAV3PrimarySaleMarketplace _marketplace,
+        IKODAV3GatedMarketplace _gatedMarketplace,
+        ICollabRoyaltiesRegistry _royaltiesRegistry
+    ) public initializer {
+
+        accessControls = _accessControls;
+        koda = _koda;
+        marketplace = _marketplace;
+        gatedMarketplace = _gatedMarketplace;
+        royaltiesRegistry = _royaltiesRegistry;
+
+        emit MintingFactoryCreated();
+    }
+
+    function mintBatchEdition(
+        SaleType _saleType,
+        uint16 _editionSize,
+        uint128 _startDate,
+        uint128 _basePrice,
+        uint128 _stepPrice,
+        string calldata _uri,
+        uint256 _merkleIndex,
+        bytes32[] calldata _merkleProof,
+        address _deployedRoyaltiesHandler
+    ) canMintAgain external {
+        require(accessControls.isVerifiedArtist(_merkleIndex, _msgSender(), _merkleProof), "Caller must have minter role");
+
+        // Make tokens & edition
+        uint256 editionId = koda.mintBatchEdition(_editionSize, _msgSender(), _uri);
+
+        _setupSalesMechanic(editionId, _saleType, _startDate, _basePrice, _stepPrice);
+        _recordSuccessfulMint(_msgSender());
+        _setupRoyalties(editionId, _deployedRoyaltiesHandler);
+    }
+
+    function mintBatchGatedEdition(
+        uint16 _editionSize,
+        uint256 _merkleIndex,
+        bytes32[] calldata _merkleProof,
+        address _deployedRoyaltiesHandler,
+        string calldata _uri
+    ) canMintAgain external {
+        require(accessControls.isVerifiedArtist(_merkleIndex, _msgSender(), _merkleProof), "Caller must have minter role");
+
+        // Make tokens & edition
+        uint256 editionId = koda.mintBatchEdition(_editionSize, _msgSender(), _uri);
+
+        // FIXME not to pass all phase details  - stack too deep :(
+
+        // Created gated sale
+        gatedMarketplace.createSale(editionId);
+
+        _recordSuccessfulMint(_msgSender());
+        _setupRoyalties(editionId, _deployedRoyaltiesHandler);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal view override {
+        require(accessControls.hasAdminRole(msg.sender), "Only admin can upgrade");
+    }
+
+    function mintBatchEditionAsProxy(
+        address _creator,
+        SaleType _saleType,
+        uint16 _editionSize,
+        uint128 _startDate,
+        uint128 _basePrice,
+        uint128 _stepPrice,
+        string calldata _uri,
+        address _deployedRoyaltiesHandler
+    ) canMintAgain external {
+        require(accessControls.isVerifiedArtistProxy(_creator, _msgSender()), "Caller is not artist proxy");
+
+        // Make tokens & edition
+        uint256 editionId = koda.mintBatchEdition(_editionSize, _creator, _uri);
+
+        _setupSalesMechanic(editionId, _saleType, _startDate, _basePrice, _stepPrice);
+        _recordSuccessfulMint(_creator);
+        _setupRoyalties(editionId, _deployedRoyaltiesHandler);
+    }
+
+    function _setupSalesMechanic(uint256 _editionId, SaleType _saleType, uint128 _startDate, uint128 _basePrice, uint128 _stepPrice) internal {
+        if (SaleType.BUY_NOW == _saleType) {
+            marketplace.listForBuyNow(_msgSender(), _editionId, _basePrice, _startDate);
+        }
+        else if (SaleType.STEPPED == _saleType) {
+            marketplace.listSteppedEditionAuction(_msgSender(), _editionId, _basePrice, _stepPrice, _startDate);
+        }
+        else if (SaleType.OFFERS == _saleType) {
+            marketplace.enableEditionOffers(_editionId, _startDate);
+        }
+        else if (SaleType.RESERVE == _saleType) {
+            // use base price for reserve price
+            marketplace.listForReserveAuction(_msgSender(), _editionId, _basePrice, _startDate);
+        }
+
+        emit EditionMintedAndListed(_editionId, _saleType);
+    }
+
+    function _setupRoyalties(uint256 _editionId, address _deployedHandler) internal {
+        if (_deployedHandler != address(0) && address(royaltiesRegistry) != address(0)) {
+            royaltiesRegistry.useRoyaltiesRecipient(_editionId, _deployedHandler);
+        }
+    }
+
+    /// Internal helpers
+
+    function _canCreateNewEdition(address _account) internal view returns (bool) {
+        // if frequency is overridden then assume they can mint
+        if (frequencyOverride[_account]) {
+            return true;
+        }
+
+        // if within the period range, check remaining allowance
+        if (_getNow() <= mintingPeriodConfig[_account].firstMintInPeriod + mintingPeriod) {
+            return mintingPeriodConfig[_account].mints < maxMintsInPeriod;
+        }
+
+        // if period expired - can mint another one
+        return true;
+    }
+
+    function _recordSuccessfulMint(address _account) internal {
+        MintingPeriod storage period = mintingPeriodConfig[_account];
+
+        uint256 endOfCurrentMintingPeriodLimit = period.firstMintInPeriod + mintingPeriod;
+
+        // if first time use, set the first timestamp to be now abd start counting
+        if (period.firstMintInPeriod == 0) {
+            period.firstMintInPeriod = _getNow();
+            period.mints = period.mints + 1;
+        }
+        // if still within the minting period, record the new mint
+        else if (_getNow() <= endOfCurrentMintingPeriodLimit) {
+            period.mints = period.mints + 1;
+        }
+        // if we are outside of the window reset the limit and record a new single mint
+        else if (endOfCurrentMintingPeriodLimit < _getNow()) {
+            period.mints = 1;
+            period.firstMintInPeriod = _getNow();
+        }
+    }
+
+    function _getNow() internal virtual view returns (uint128) {
+        return uint128(block.timestamp);
+    }
+
+    /// Public helpers
+
+    function canCreateNewEdition(address _account) public view returns (bool) {
+        return _canCreateNewEdition(_account);
+    }
+
+    function currentMintConfig(address _account) public view returns (uint128 mints, uint128 firstMintInPeriod) {
+        MintingPeriod memory config = mintingPeriodConfig[_account];
+        return (
+        config.mints,
+        config.firstMintInPeriod
+        );
+    }
+
+    function setFrequencyOverride(address _account, bool _override) onlyAdmin public {
+        frequencyOverride[_account] = _override;
+        emit AdminFrequencyOverrideChanged(_account, _override);
+    }
+
+    function setMintingPeriod(uint256 _mintingPeriod) onlyAdmin public {
+        mintingPeriod = _mintingPeriod;
+        emit AdminMintingPeriodChanged(_mintingPeriod);
+    }
+
+    function setRoyaltiesRegistry(ICollabRoyaltiesRegistry _royaltiesRegistry) onlyAdmin public {
+        royaltiesRegistry = _royaltiesRegistry;
+        emit AdminRoyaltiesRegistryChanged(address(_royaltiesRegistry));
+    }
+
+    function setMaxMintsInPeriod(uint256 _maxMintsInPeriod) onlyAdmin public {
+        maxMintsInPeriod = _maxMintsInPeriod;
+        emit AdminMaxMintsInPeriodChanged(_maxMintsInPeriod);
+    }
+
+}

--- a/test/marketplace/KODAV3GatedMarketplace.complex.test.js
+++ b/test/marketplace/KODAV3GatedMarketplace.complex.test.js
@@ -10,394 +10,458 @@ const KOAccessControls = artifacts.require('KOAccessControls');
 const SelfServiceAccessControls = artifacts.require('SelfServiceAccessControls');
 const MockERC20 = artifacts.require('MockERC20');
 const KODAV3UpgradableGatedMarketplace = artifacts.require('KODAV3UpgradableGatedMarketplace');
+const KODAV3PrimaryMarketplace = artifacts.require('KODAV3PrimaryMarketplace');
 
 contract('BasicGatedSale complex tests...', function () {
 
-    const STARTING_EDITION = '10000';
-    const TOKEN_URI = 'ipfs://ipfs/Qmd9xQFBfqMZLG7RA2rXor7SA7qyJ1Pk2F2mSYzRQ2siMv';
-    const MOCK_MERKLE_HASH = 'Qmd9xQFBfqMZLG7RA2rXor7SA7qyJ1Pk2F2mSYzRQ2siMv';
-    const ZERO = new BN('0');
-    const ONE = new BN('1');
-    const TWO = new BN('2');
-    const THREE = new BN('3');
-    const FIVE = new BN('5');
-    const TEN = new BN('10');
+  const STARTING_EDITION = '10000';
+  const TOKEN_URI = 'ipfs://ipfs/Qmd9xQFBfqMZLG7RA2rXor7SA7qyJ1Pk2F2mSYzRQ2siMv';
+  const MOCK_MERKLE_HASH = 'Qmd9xQFBfqMZLG7RA2rXor7SA7qyJ1Pk2F2mSYzRQ2siMv';
+  const ZERO = new BN('0');
+  const ONE = new BN('1');
+  const TWO = new BN('2');
+  const THREE = new BN('3');
+  const FIVE = new BN('5');
+  const TEN = new BN('10');
 
-    const FIRST_MINTED_TOKEN_ID = new BN('11000'); // this is implied
-    let CURRENT_TOKEN_ID = FIRST_MINTED_TOKEN_ID;
+  const FIRST_MINTED_TOKEN_ID = new BN('11000'); // this is implied
+  let CURRENT_TOKEN_ID = FIRST_MINTED_TOKEN_ID;
 
-    let owner, admin, koCommission, contract, artist, buyer1, buyer2, buyer3, buyer4, buyer5;
+  let owner, admin, koCommission, contract, artist, buyer1, buyer2, buyer3, buyer4, buyer5;
 
-    beforeEach(async () => {
-        [owner, admin, koCommission, contract, artist, buyer1, buyer2, buyer3, buyer4, buyer5] = await ethers.getSigners();
+  beforeEach(async () => {
+    [owner, admin, koCommission, contract, artist, buyer1, buyer2, buyer3, buyer4, buyer5] = await ethers.getSigners();
 
-        this.merkleProof1 = parseBalanceMap(buildArtistMerkleInput(1, buyer1.address, buyer2.address));
-        this.merkleProof2 = parseBalanceMap(buildArtistMerkleInput(1, buyer1.address, buyer2.address, buyer3.address, buyer4.address));
-        this.merkleProof3 = parseBalanceMap(buildArtistMerkleInput(1, buyer1.address, buyer2.address, buyer3.address, buyer4.address, buyer5.address));
+    this.merkleProof1 = parseBalanceMap(buildArtistMerkleInput(1, buyer1.address, buyer2.address));
+    this.merkleProof2 = parseBalanceMap(buildArtistMerkleInput(1, buyer1.address, buyer2.address, buyer3.address, buyer4.address));
+    this.merkleProof3 = parseBalanceMap(buildArtistMerkleInput(1, buyer1.address, buyer2.address, buyer3.address, buyer4.address, buyer5.address));
 
-        this.legacyAccessControls = await SelfServiceAccessControls.new();
+    this.legacyAccessControls = await SelfServiceAccessControls.new();
 
-        // setup access controls
-        this.accessControls = await KOAccessControls.new(this.legacyAccessControls.address, {from: owner.address});
+    // setup access controls
+    this.accessControls = await KOAccessControls.new(this.legacyAccessControls.address, {from: owner.address});
 
-        // grab the roles
-        this.CONTRACT_ROLE = await this.accessControls.CONTRACT_ROLE();
-        this.DEFAULT_ADMIN_ROLE = await this.accessControls.DEFAULT_ADMIN_ROLE();
+    // grab the roles
+    this.CONTRACT_ROLE = await this.accessControls.CONTRACT_ROLE();
+    this.DEFAULT_ADMIN_ROLE = await this.accessControls.DEFAULT_ADMIN_ROLE();
 
-        // Create token V3
-        this.token = await KnownOriginDigitalAssetV3.new(
-            this.accessControls.address,
-            ZERO_ADDRESS, // no royalties address
-            STARTING_EDITION,
-            {from: owner.address}
-        );
+    // Create token V3
+    this.token = await KnownOriginDigitalAssetV3.new(
+      this.accessControls.address,
+      ZERO_ADDRESS, // no royalties address
+      STARTING_EDITION,
+      {from: owner.address}
+    );
 
-        await this.accessControls.grantRole(this.DEFAULT_ADMIN_ROLE, admin.address, {from: owner.address});
-        await this.accessControls.grantRole(this.CONTRACT_ROLE, this.token.address, {from: owner.address});
+    await this.accessControls.grantRole(this.DEFAULT_ADMIN_ROLE, admin.address, {from: owner.address});
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, this.token.address, {from: owner.address});
 
-        // Note: this is a test hack so we can mint tokens direct
-        await this.accessControls.grantRole(this.CONTRACT_ROLE, contract.address, {from: owner.address});
+    // Note: this is a test hack so we can mint tokens direct
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, contract.address, {from: owner.address});
 
-        this.basicGatedSale = await upgrades.deployProxy(
-            await ethers.getContractFactory('KODAV3UpgradableGatedMarketplace'),
-            [this.accessControls.address, this.token.address, koCommission.address],
-            {initializer: 'initialize', kind: 'uups'}
-        );
+    this.basicGatedSale = await upgrades.deployProxy(
+      await ethers.getContractFactory('KODAV3UpgradableGatedMarketplace'),
+      [this.accessControls.address, this.token.address, koCommission.address],
+      {initializer: 'initialize', kind: 'uups'}
+    );
 
-        await this.accessControls.grantRole(this.CONTRACT_ROLE, this.basicGatedSale.address, {from: owner.address});
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, this.basicGatedSale.address, {from: owner.address});
 
-        // create 22 tokens to the minter
-        await this.token.mintBatchEdition(29, artist.address, TOKEN_URI, {from: contract.address});
+    // create 22 tokens to the minter
+    await this.token.mintBatchEdition(29, artist.address, TOKEN_URI, {from: contract.address});
 
-        // Ensure basic gated sale has approval to sell tokens
-        await this.token.setApprovalForAll(this.basicGatedSale.address, true, {from: artist.address});
+    // Ensure basic gated sale has approval to sell tokens
+    await this.token.setApprovalForAll(this.basicGatedSale.address, true, {from: artist.address});
 
-        // just for stuck tests
-        this.erc20Token = await MockERC20.new({from: owner.address});
+    // Setup primary marketplace
+    this.marketplace = await KODAV3PrimaryMarketplace.new(this.accessControls.address, this.token.address, koCommission.address, {from: owner.address});
+    await this.accessControls.grantRole(this.CONTRACT_ROLE, this.marketplace.address, {from: owner.address});
+    await this.token.setApprovalForAll(this.marketplace.address, true, {from: artist.address});
 
-        // Set a root time, then a start and end time, simulating sale running for a day
-        this.rootTime = await time.latest();
+    // just for stuck tests
+    this.erc20Token = await MockERC20.new({from: owner.address});
 
-        this.phase1Start = this.rootTime.add(time.duration.hours(1));
-        this.phase1End = this.rootTime.add(time.duration.hours(25));
+    // Set a root time, then a start and end time, simulating sale running for a day
+    this.rootTime = await time.latest();
 
-        this.phase2Start = this.phase1End;
-        this.phase2End = this.phase2Start.add(time.duration.days(2));
+    this.phase1Start = this.rootTime.add(time.duration.hours(1));
+    this.phase1End = this.rootTime.add(time.duration.hours(25));
 
-        this.phase3Start = this.phase2End;
-        this.phase3End = this.phase3Start.add(time.duration.days(7));
-    });
+    this.phase2Start = this.phase1End;
+    this.phase2End = this.phase2Start.add(time.duration.days(2));
 
-    describe('BasicGatedSale - Complex', async () => {
+    this.phase3Start = this.phase2End;
+    this.phase3End = this.phase3Start.add(time.duration.days(7));
+  });
 
-        it('can create a sale with multiple phases and manage mints from each', async () => {
-            // Make the sale
-            const creationReceipt = await this.basicGatedSale.connect(artist).createSaleWithPhases(
-                FIRST_MINTED_TOKEN_ID.toString(),
-                [this.phase1Start.toString()],
-                [this.phase1End.toString()],
-                [ether('0.1').toString()],
-                ['29'],
-                [THREE.toString()],
-                [this.merkleProof1.merkleRoot],
-                [MOCK_MERKLE_HASH],
-            );
+  describe('BasicGatedSale - Complex', async () => {
 
-            await expectEvent.inTransaction(creationReceipt.hash, KODAV3UpgradableGatedMarketplace, 'SaleWithPhaseCreated', {
-                _saleId: ONE
-            });
+    it('can create a sale with multiple phases and manage mints from each', async () => {
+      // Make the sale
+      const creationReceipt = await this.basicGatedSale.connect(artist).createSaleWithPhases(
+        FIRST_MINTED_TOKEN_ID.toString(),
+        [this.phase1Start.toString()],
+        [this.phase1End.toString()],
+        [ether('0.1').toString()],
+        ['29'],
+        [THREE.toString()],
+        [this.merkleProof1.merkleRoot],
+        [MOCK_MERKLE_HASH],
+      );
 
-            // Add a second phase
-            const phase2Receipt = await this.basicGatedSale.connect(artist).createPhase(
-                FIRST_MINTED_TOKEN_ID.toString(),
-                this.phase2Start.toString(),
-                this.phase2End.toString(),
-                ether('0.3').toString(),
-                '29',
-                FIVE.toString(),
-                this.merkleProof2.merkleRoot,
-                MOCK_MERKLE_HASH
-            );
+      await expectEvent.inTransaction(creationReceipt.hash, KODAV3UpgradableGatedMarketplace, 'SaleWithPhaseCreated', {
+        _saleId: ONE
+      });
 
-            await expectEvent.inTransaction(phase2Receipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseCreated', {
-                _saleId: ONE,
-                _phaseId: ONE
-            });
+      // Add a second phase
+      const phase2Receipt = await this.basicGatedSale.connect(artist).createPhase(
+        FIRST_MINTED_TOKEN_ID.toString(),
+        this.phase2Start.toString(),
+        this.phase2End.toString(),
+        ether('0.3').toString(),
+        '29',
+        FIVE.toString(),
+        this.merkleProof2.merkleRoot,
+        MOCK_MERKLE_HASH
+      );
 
-            // Add a third phase
-            const phase3Receipt = await this.basicGatedSale.connect(artist).createPhase(
-                FIRST_MINTED_TOKEN_ID.toString(),
-                this.phase3Start.toString(),
-                this.phase3End.toString(),
-                ether('0.5').toString(),
-                '29',
-                TEN.toString(),
-                this.merkleProof3.merkleRoot,
-                MOCK_MERKLE_HASH
-            );
+      await expectEvent.inTransaction(phase2Receipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseCreated', {
+        _saleId: ONE,
+        _phaseId: ONE
+      });
 
-            await expectEvent.inTransaction(phase3Receipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseCreated', {
-                _saleId: ONE,
-                _phaseId: TWO
-            });
+      // Add a third phase
+      const phase3Receipt = await this.basicGatedSale.connect(artist).createPhase(
+        FIRST_MINTED_TOKEN_ID.toString(),
+        this.phase3Start.toString(),
+        this.phase3End.toString(),
+        ether('0.5').toString(),
+        '29',
+        TEN.toString(),
+        this.merkleProof3.merkleRoot,
+        MOCK_MERKLE_HASH
+      );
 
-            // Delete a phase
-            const phase3DeleteReceipt = await this.basicGatedSale.connect(artist).removePhase(
-                FIRST_MINTED_TOKEN_ID.toString(),
-                TWO.toString()
-            );
+      await expectEvent.inTransaction(phase3Receipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseCreated', {
+        _saleId: ONE,
+        _phaseId: TWO
+      });
 
-            await expectEvent.inTransaction(phase3DeleteReceipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseRemoved', {
-                _saleId: ONE,
-                _phaseId: TWO
-            });
+      // Delete a phase
+      const phase3DeleteReceipt = await this.basicGatedSale.connect(artist).removePhase(
+        FIRST_MINTED_TOKEN_ID.toString(),
+        TWO.toString()
+      );
 
-            // Simulate someone else trying to add a phase
-            await expectRevert(this.basicGatedSale.connect(buyer4).createPhase(
-                    FIRST_MINTED_TOKEN_ID.toString(),
-                    this.phase3Start.toString(),
-                    this.phase3End.toString(),
-                    ether('0.5').toString(),
-                    '29',
-                    TEN.toString(),
-                    this.merkleProof3.merkleRoot,
-                    MOCK_MERKLE_HASH
-                ),
-                'Caller not creator or admin');
+      await expectEvent.inTransaction(phase3DeleteReceipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseRemoved', {
+        _saleId: ONE,
+        _phaseId: TWO
+      });
 
-            // Add the third phase again
-            const phase3NewReceipt = await this.basicGatedSale.connect(artist).createPhase(
-                FIRST_MINTED_TOKEN_ID.toString(),
-                this.phase3Start.toString(),
-                this.phase3End.toString(),
-                ether('0.7').toString(),
-                '29',
-                TEN.toString(),
-                this.merkleProof3.merkleRoot,
-                MOCK_MERKLE_HASH
-            );
+      // Simulate someone else trying to add a phase
+      await expectRevert(this.basicGatedSale.connect(buyer4).createPhase(
+          FIRST_MINTED_TOKEN_ID.toString(),
+          this.phase3Start.toString(),
+          this.phase3End.toString(),
+          ether('0.5').toString(),
+          '29',
+          TEN.toString(),
+          this.merkleProof3.merkleRoot,
+          MOCK_MERKLE_HASH
+        ),
+        'Caller not creator or admin');
 
-            await expectEvent.inTransaction(phase3NewReceipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseCreated', {
-                _saleId: ONE,
-                _phaseId: THREE
-            });
+      // Add the third phase again
+      const phase3NewReceipt = await this.basicGatedSale.connect(artist).createPhase(
+        FIRST_MINTED_TOKEN_ID.toString(),
+        this.phase3Start.toString(),
+        this.phase3End.toString(),
+        ether('0.7').toString(),
+        '29',
+        TEN.toString(),
+        this.merkleProof3.merkleRoot,
+        MOCK_MERKLE_HASH
+      );
 
-            // Try and mint before the test starts
-            await expectRevert(this.basicGatedSale.connect(buyer1).mint(
-                ONE.toString(),
-                ZERO.toString(),
-                ONE.toString(),
-                this.merkleProof1.claims[buyer1.address].index,
-                this.merkleProof1.claims[buyer1.address].proof,
-                {
-                    value: ether('0.1').toString()
-                }), 'Sale phase not in progress');
+      await expectEvent.inTransaction(phase3NewReceipt.hash, KODAV3UpgradableGatedMarketplace, 'PhaseCreated', {
+        _saleId: ONE,
+        _phaseId: THREE
+      });
 
-            // Advance time to the first phase
-            await time.increaseTo(this.phase1Start.add(time.duration.minutes(1)));
+      // Try and mint before the test starts
+      await expectRevert(this.basicGatedSale.connect(buyer1).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        ONE.toString(),
+        this.merkleProof1.claims[buyer1.address].index,
+        this.merkleProof1.claims[buyer1.address].proof,
+        {
+          value: ether('0.1').toString()
+        }), 'Sale phase not in progress');
 
-            // Max out buyer1's allowance and prove you can't go over
-            const b1p1MintReceipt = await this.basicGatedSale.connect(buyer1).mint(
-                ONE.toString(),
-                ZERO.toString(),
-                THREE.toString(),
-                this.merkleProof1.claims[buyer1.address].index,
-                this.merkleProof1.claims[buyer1.address].proof,
-                {
-                    value: ether('0.3').toString()
-                });
+      // Advance time to the first phase
+      await time.increaseTo(this.phase1Start.add(time.duration.minutes(1)));
 
-            await expectEvent.inTransaction(b1p1MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
-                _saleId: ONE,
-                _phaseId: ZERO,
-                _tokenId: FIRST_MINTED_TOKEN_ID,
-                _recipient: buyer1.address
-            });
-
-            expect(await this.token.ownerOf(FIRST_MINTED_TOKEN_ID)).to.be.equal(buyer1.address);
-
-            CURRENT_TOKEN_ID = FIRST_MINTED_TOKEN_ID.add(ONE);
-            expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer1.address);
-
-            CURRENT_TOKEN_ID = CURRENT_TOKEN_ID.add(ONE);
-            expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer1.address);
-
-            await expectRevert(this.basicGatedSale.connect(buyer1).mint(
-                ONE.toString(),
-                ZERO.toString(),
-                ONE.toString(),
-                this.merkleProof1.claims[buyer1.address].index,
-                this.merkleProof1.claims[buyer1.address].proof,
-                {
-                    value: ether('0.1').toString()
-                }), 'Cannot exceed total mints for sale phase');
-
-            // Mint from buyer 2 as well
-            let b2p1MintReceipt = await this.basicGatedSale.connect(buyer2).mint(
-                ONE.toString(),
-                ZERO.toString(),
-                TWO.toString(),
-                this.merkleProof1.claims[buyer2.address].index,
-                this.merkleProof1.claims[buyer2.address].proof,
-                {
-                    value: ether('0.2').toString()
-                });
-
-            await expectEvent.inTransaction(b2p1MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
-                _saleId: ONE,
-                _phaseId: ZERO,
-                _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('3')),
-                _recipient: buyer2.address
-            });
-
-            CURRENT_TOKEN_ID = CURRENT_TOKEN_ID.add(ONE);
-            expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer2.address);
-
-            CURRENT_TOKEN_ID = CURRENT_TOKEN_ID.add(ONE);
-            expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer2.address);
-
-            // Try and mint from someone not in the phase whitelist
-            await expectRevert(this.basicGatedSale.connect(buyer4).mint(
-                ONE.toString(),
-                ZERO.toString(),
-                ONE.toString(),
-                this.merkleProof3.claims[buyer1.address].index,
-                this.merkleProof3.claims[buyer1.address].proof,
-                {
-                    value: ether('0.1').toString()
-                }), 'Address not able to mint from sale');
-
-            // Advance time to phase2 and move the sale on
-            await time.increaseTo(this.phase2Start.add(time.duration.minutes(1)));
-
-            // Check you can no longer mint from the first phase if it has finished
-            await expectRevert(this.basicGatedSale.connect(buyer2).mint(
-                ONE.toString(),
-                ZERO.toString(),
-                ONE.toString(),
-                this.merkleProof2.claims[buyer2.address].index,
-                this.merkleProof2.claims[buyer2.address].proof,
-                {
-                    value: ether('0.1').toString()
-                }), 'Sale phase not in progress');
-
-            // You can mint from phase 2 now though
-            let b2p2MintReceipt = await this.basicGatedSale.connect(buyer2).mint(
-                ONE.toString(),
-                ONE.toString(),
-                THREE.toString(),
-                this.merkleProof2.claims[buyer2.address].index,
-                this.merkleProof2.claims[buyer2.address].proof,
-                {
-                    value: ether('0.9').toString()
-                });
-
-            await expectEvent.inTransaction(b2p2MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
-                _saleId: ONE,
-                _phaseId: ONE,
-                _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('5')),
-                _recipient: buyer2.address
-            });
-
-            // And new members of the prelist can also mint
-            let b4p2MintReceipt = await this.basicGatedSale.connect(buyer4).mint(
-                ONE.toString(),
-                ONE.toString(),
-                ONE.toString(),
-                this.merkleProof2.claims[buyer4.address].index,
-                this.merkleProof2.claims[buyer4.address].proof,
-                {
-                    value: ether('0.3').toString()
-                });
-
-            await expectEvent.inTransaction(b4p2MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
-                _saleId: ONE,
-                _phaseId: ONE,
-                _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('8')),
-                _recipient: buyer4.address
-            });
-
-            // but not if they don't send enough ETH
-            await expectRevert(this.basicGatedSale.connect(buyer3).mint(
-                ONE.toString(),
-                ONE.toString(),
-                TWO.toString(),
-                this.merkleProof3.claims[buyer3.address].index,
-                this.merkleProof3.claims[buyer3.address].proof,
-                {
-                    value: ether('0.5').toString()
-                }), 'Not enough wei sent to complete mint');
-
-            // buyer5 should still not be able to mint as well
-            await expectRevert(this.basicGatedSale.connect(buyer3).mint(
-                ONE.toString(),
-                ONE.toString(),
-                ONE.toString(),
-                this.merkleProof3.claims[buyer3.address].index,
-                this.merkleProof3.claims[buyer3.address].proof,
-                {
-                    value: ether('0.3').toString()
-                }), 'Address not able to mint from sale');
-
-            // You are also unable to mint if you give the deleted phase id
-            await expectRevert(this.basicGatedSale.connect(buyer3).mint(
-                ONE.toString(),
-                TWO.toString(),
-                ONE.toString(),
-                this.merkleProof2.claims[buyer3.address].index,
-                this.merkleProof2.claims[buyer3.address].proof,
-                {
-                    value: ether('0.3').toString()
-                }), 'Sale phase not in progress');
-
-            // They will be able to mint when we advance to phase 3 though
-            await time.increaseTo(this.phase3Start);
-
-            let b5p3MintReceipt = await this.basicGatedSale.connect(buyer5).mint(
-                ONE.toString(),
-                THREE.toString(),
-                new BN('10').toString(),
-                this.merkleProof3.claims[buyer5.address].index,
-                this.merkleProof3.claims[buyer5.address].proof,
-                {
-                    value: ether('7').toString()
-                });
-
-            await expectEvent.inTransaction(b5p3MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
-                _saleId: ONE,
-                _phaseId: THREE,
-                _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('15')),
-                _recipient: buyer5.address
-            });
-
-            // Lets get someone else to buy a load as well
-            let b2p3MintReceipt = await this.basicGatedSale.connect(buyer2).mint(
-                ONE.toString(),
-                THREE.toString(),
-                new BN('10').toString(),
-                this.merkleProof3.claims[buyer2.address].index,
-                this.merkleProof3.claims[buyer2.address].proof,
-                {
-                    value: ether('7').toString()
-                });
-
-            await expectEvent.inTransaction(b2p3MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
-                _saleId: ONE,
-                _phaseId: THREE,
-                _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('19')),
-                _recipient: buyer2.address
-            });
-
-            // The sale should now be sold out so should revert
-            await expectRevert(this.basicGatedSale.connect(buyer1).mint(
-                ONE.toString(),
-                THREE.toString(),
-                ONE.toString(),
-                this.merkleProof3.claims[buyer1.address].index,
-                this.merkleProof3.claims[buyer1.address].proof,
-                {
-                    value: ether('0.7').toString()
-                }), 'Primary market exhausted');
+      // Max out buyer1's allowance and prove you can't go over
+      const b1p1MintReceipt = await this.basicGatedSale.connect(buyer1).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        THREE.toString(),
+        this.merkleProof1.claims[buyer1.address].index,
+        this.merkleProof1.claims[buyer1.address].proof,
+        {
+          value: ether('0.3').toString()
         });
+
+      await expectEvent.inTransaction(b1p1MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: ZERO,
+        _tokenId: FIRST_MINTED_TOKEN_ID,
+        _recipient: buyer1.address
+      });
+
+      expect(await this.token.ownerOf(FIRST_MINTED_TOKEN_ID)).to.be.equal(buyer1.address);
+
+      CURRENT_TOKEN_ID = FIRST_MINTED_TOKEN_ID.add(ONE);
+      expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer1.address);
+
+      CURRENT_TOKEN_ID = CURRENT_TOKEN_ID.add(ONE);
+      expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer1.address);
+
+      await expectRevert(this.basicGatedSale.connect(buyer1).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        ONE.toString(),
+        this.merkleProof1.claims[buyer1.address].index,
+        this.merkleProof1.claims[buyer1.address].proof,
+        {
+          value: ether('0.1').toString()
+        }), 'Cannot exceed total mints for sale phase');
+
+      // Mint from buyer 2 as well
+      let b2p1MintReceipt = await this.basicGatedSale.connect(buyer2).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        TWO.toString(),
+        this.merkleProof1.claims[buyer2.address].index,
+        this.merkleProof1.claims[buyer2.address].proof,
+        {
+          value: ether('0.2').toString()
+        });
+
+      await expectEvent.inTransaction(b2p1MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: ZERO,
+        _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('3')),
+        _recipient: buyer2.address
+      });
+
+      CURRENT_TOKEN_ID = CURRENT_TOKEN_ID.add(ONE);
+      expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer2.address);
+
+      CURRENT_TOKEN_ID = CURRENT_TOKEN_ID.add(ONE);
+      expect(await this.token.ownerOf(CURRENT_TOKEN_ID)).to.be.equal(buyer2.address);
+
+      // Try and mint from someone not in the phase whitelist
+      await expectRevert(this.basicGatedSale.connect(buyer4).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        ONE.toString(),
+        this.merkleProof3.claims[buyer1.address].index,
+        this.merkleProof3.claims[buyer1.address].proof,
+        {
+          value: ether('0.1').toString()
+        }), 'Address not able to mint from sale');
+
+      // Advance time to phase2 and move the sale on
+      await time.increaseTo(this.phase2Start.add(time.duration.minutes(1)));
+
+      // Check you can no longer mint from the first phase if it has finished
+      await expectRevert(this.basicGatedSale.connect(buyer2).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        ONE.toString(),
+        this.merkleProof2.claims[buyer2.address].index,
+        this.merkleProof2.claims[buyer2.address].proof,
+        {
+          value: ether('0.1').toString()
+        }), 'Sale phase not in progress');
+
+      // You can mint from phase 2 now though
+      let b2p2MintReceipt = await this.basicGatedSale.connect(buyer2).mint(
+        ONE.toString(),
+        ONE.toString(),
+        THREE.toString(),
+        this.merkleProof2.claims[buyer2.address].index,
+        this.merkleProof2.claims[buyer2.address].proof,
+        {
+          value: ether('0.9').toString()
+        });
+
+      await expectEvent.inTransaction(b2p2MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: ONE,
+        _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('5')),
+        _recipient: buyer2.address
+      });
+
+      // And new members of the prelist can also mint
+      let b4p2MintReceipt = await this.basicGatedSale.connect(buyer4).mint(
+        ONE.toString(),
+        ONE.toString(),
+        ONE.toString(),
+        this.merkleProof2.claims[buyer4.address].index,
+        this.merkleProof2.claims[buyer4.address].proof,
+        {
+          value: ether('0.3').toString()
+        });
+
+      await expectEvent.inTransaction(b4p2MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: ONE,
+        _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('8')),
+        _recipient: buyer4.address
+      });
+
+      // but not if they don't send enough ETH
+      await expectRevert(this.basicGatedSale.connect(buyer3).mint(
+        ONE.toString(),
+        ONE.toString(),
+        TWO.toString(),
+        this.merkleProof3.claims[buyer3.address].index,
+        this.merkleProof3.claims[buyer3.address].proof,
+        {
+          value: ether('0.5').toString()
+        }), 'Not enough wei sent to complete mint');
+
+      // buyer5 should still not be able to mint as well
+      await expectRevert(this.basicGatedSale.connect(buyer3).mint(
+        ONE.toString(),
+        ONE.toString(),
+        ONE.toString(),
+        this.merkleProof3.claims[buyer3.address].index,
+        this.merkleProof3.claims[buyer3.address].proof,
+        {
+          value: ether('0.3').toString()
+        }), 'Address not able to mint from sale');
+
+      // You are also unable to mint if you give the deleted phase id
+      await expectRevert(this.basicGatedSale.connect(buyer3).mint(
+        ONE.toString(),
+        TWO.toString(),
+        ONE.toString(),
+        this.merkleProof2.claims[buyer3.address].index,
+        this.merkleProof2.claims[buyer3.address].proof,
+        {
+          value: ether('0.3').toString()
+        }), 'Sale phase not in progress');
+
+      // They will be able to mint when we advance to phase 3 though
+      await time.increaseTo(this.phase3Start);
+
+      let b5p3MintReceipt = await this.basicGatedSale.connect(buyer5).mint(
+        ONE.toString(),
+        THREE.toString(),
+        new BN('10').toString(),
+        this.merkleProof3.claims[buyer5.address].index,
+        this.merkleProof3.claims[buyer5.address].proof,
+        {
+          value: ether('7').toString()
+        });
+
+      await expectEvent.inTransaction(b5p3MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: THREE,
+        _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('15')),
+        _recipient: buyer5.address
+      });
+
+      // Lets get someone else to buy a load as well
+      let b2p3MintReceipt = await this.basicGatedSale.connect(buyer2).mint(
+        ONE.toString(),
+        THREE.toString(),
+        new BN('10').toString(),
+        this.merkleProof3.claims[buyer2.address].index,
+        this.merkleProof3.claims[buyer2.address].proof,
+        {
+          value: ether('7').toString()
+        });
+
+      await expectEvent.inTransaction(b2p3MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: THREE,
+        _tokenId: FIRST_MINTED_TOKEN_ID.add(new BN('19')),
+        _recipient: buyer2.address
+      });
+
+      // The sale should now be sold out so should revert
+      await expectRevert(this.basicGatedSale.connect(buyer1).mint(
+        ONE.toString(),
+        THREE.toString(),
+        ONE.toString(),
+        this.merkleProof3.claims[buyer1.address].index,
+        this.merkleProof3.claims[buyer1.address].proof,
+        {
+          value: ether('0.7').toString()
+        }), 'Primary market exhausted');
     });
+
+    it.only('can create a gated sale and still list and sell as buy now', async () => {
+
+      // Make the sale
+      const creationReceipt = await this.basicGatedSale.connect(artist).createSaleWithPhases(
+        FIRST_MINTED_TOKEN_ID.toString(),
+        [this.phase1Start.toString()],
+        [this.phase1End.toString()],
+        [ether('0.1').toString()],
+        ['29'],
+        [THREE.toString()],
+        [this.merkleProof1.merkleRoot],
+        [MOCK_MERKLE_HASH],
+      );
+
+      await expectEvent.inTransaction(creationReceipt.hash, KODAV3UpgradableGatedMarketplace, 'SaleWithPhaseCreated', {
+        _saleId: ONE
+      });
+
+      const _0_1_ETH = ether('0.1');
+
+      // TODO THIS FAILS
+      // await this.marketplace.listForBuyNow(artist.address, FIRST_MINTED_TOKEN_ID, _0_1_ETH, '0', {from: artist.address});
+
+      // Setup as buy now as emergency
+      const {receipt} = await this.marketplace.convertOffersToBuyItNow(FIRST_MINTED_TOKEN_ID, _0_1_ETH, '0', {from: artist.address});
+      await expectEvent(receipt, 'EditionConvertedFromOffersToBuyItNow', {
+        _editionId: FIRST_MINTED_TOKEN_ID,
+        _price: _0_1_ETH,
+        _startDate: new BN('0')
+      });
+
+      // test buy
+      await this.marketplace.buyEditionToken(FIRST_MINTED_TOKEN_ID, {from: buyer1.address, value: _0_1_ETH});
+      expect(await this.token.ownerOf(FIRST_MINTED_TOKEN_ID)).to.be.equal(buyer1.address);
+
+
+      // Advance time to the first phase
+      await time.increaseTo(this.phase1Start.add(time.duration.minutes(1)));
+
+      // Buy one via the gated sale
+      const b1p1MintReceipt = await this.basicGatedSale.connect(buyer1).mint(
+        ONE.toString(),
+        ZERO.toString(),
+        THREE.toString(),
+        this.merkleProof1.claims[buyer1.address].index,
+        this.merkleProof1.claims[buyer1.address].proof,
+        {
+          value: ether('0.3').toString()
+        });
+
+      await expectEvent.inTransaction(b1p1MintReceipt.hash, KODAV3UpgradableGatedMarketplace, 'MintFromSale', {
+        _saleId: ONE,
+        _phaseId: ZERO,
+        _tokenId: FIRST_MINTED_TOKEN_ID.add(ONE),
+        _recipient: buyer1.address
+      });
+    });
+  });
 });


### PR DESCRIPTION
* [ ] Upgradable minting factory (v2)
* [ ] Additional miniting method for only minting editions and not putting on sale
* [ ] Additional mintning method for gated sales
	* [ ] As creator
	* [ ] As proxy
* [ ] Remove unused methods for minting composable upfront
* [ ] Extra common interfaces
* [ ] **TODO** - do we need a method to mint as buy now and create a sale?